### PR TITLE
Reviewed the /view template. Fix /remove bug

### DIFF
--- a/SQL-snippets/schema.sql
+++ b/SQL-snippets/schema.sql
@@ -21,9 +21,9 @@ create table public.invites (
   created_at timestamp NOT NULL,
   unique (sender_discord_id, receiver_discord_id),
   constraint fk_sender_discord_id
-    foreign key (sender_discord_id) 
-      references developers(discord_id),
+    foreign key (sender_discord_id)
+      references developers(discord_id) on delete cascade,
   constraint fk_receiver_discord_id
     foreign key (receiver_discord_id) 
-      references developers(discord_id)
+      references developers(discord_id) on delete cascade
 )

--- a/commands/invite.ts
+++ b/commands/invite.ts
@@ -132,9 +132,10 @@ export async function execute(interaction: CommandInteraction) {
         {name: 'Desired Skills', value: inviterDesiredSkills},
         {name: 'Goal', value: inviterGoal ?? "none"},
         {name: 'Available', value: inviterAvailable ? 'True' : 'False', inline: true},
+        {name: '\u200b', value: '\u200b', inline: true},
         {name: 'Timezone', value: inviterTimezone, inline: true},
-        {name: 'Github', value: `https://github.com/${inviterGithub}`, inline: true},
-        {name: 'Twitter', value: `https://twitter.com/${inviterTwitter}`, inline: true},
+        {name: 'Github', value: `__[github.com/${inviterGithub}](https://github.com/${inviterGithub})__`, inline: true},
+        {name: 'Twitter', value: `__[twitter.com/${inviterTwitter}](https://twitter.com/${inviterTwitter})__`, inline: true},
     )
 
     const acceptButton = new MessageButton()

--- a/commands/invites.ts
+++ b/commands/invites.ts
@@ -59,9 +59,10 @@ export async function execute(interaction: CommandInteraction) {
             {name: 'Desired Skills', value: inviterDesiredSkills},
             {name: 'Goal', value: inviterGoal ?? "none"},
             {name: 'Available', value: inviterAvailable ? 'True' : 'False', inline: true},
+            {name: '\u200b', value: '\u200b', inline: true},
             {name: 'Timezone', value: inviterTimezone, inline: true},
-            {name: 'Github', value: `https://github.com/${inviterGithub}`, inline: true},
-            {name: 'Twitter', value: `https://twitter.com/${inviterTwitter}`, inline: true},
+            {name: 'Github', value: `__[github.com/${inviterGithub}](https://github.com/${inviterGithub})__`, inline: true},
+            {name: 'Twitter', value: `__[twitter.com/${inviterTwitter}](https://twitter.com/${inviterTwitter})__`, inline: true},
         )
     
         pages.push(embedMessage)   

--- a/commands/view.ts
+++ b/commands/view.ts
@@ -59,9 +59,10 @@ export async function execute(interaction: CommandInteraction) {
         {name: 'Desired Skills', value: desired_skills},
         {name: 'Goal', value: goal ?? "none"},
         {name: 'Available', value: available ? 'True' : 'False', inline: true},
+        {name: '\u200b', value: '\u200b', inline: true},
         {name: 'Timezone', value: timezone, inline: true},
-        {name: 'Github', value: `https://github.com/${github}`, inline: true},
-        {name: 'Twitter', value: `https://twitter.com/${twitter}`, inline: true},
+        {name: 'Github', value: `__[github.com/${github}](https://github.com/${github})__`, inline: true},
+        {name: 'Twitter', value: `__[twitter.com/${twitter}](https://twitter.com/${twitter})__`, inline: true},
     )
 
     const inviteRow = new MessageActionRow()


### PR DESCRIPTION
This commit includes:
- Review of the /view embed
- Changed the tables script

I came up into the /remove problem when I got to /remove myself and I was in the 'invites' table. Since the discord_id in the 'invites' table is referencing the 'developers' table I couldn't /remove my record. I added an 'on delete cascade' to delete the records involved with my discord_id in the 'invites' table when I am /removing myself from the 'developers' table.