### PR TITLE
Added feature: developers paginator

### DIFF
--- a/commands/developers.ts
+++ b/commands/developers.ts
@@ -1,6 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
 import { supabase } from '../database';
+import { generateDevelopersPaginator } from '../components/developersPaginator';
 let AsciiTable = require('ascii-table')
 
 export const data = new SlashCommandBuilder()
@@ -33,22 +34,6 @@ export async function execute(interaction: CommandInteraction) {
         return
     }
 
-    // create developer table
-    let developerTable = new AsciiTable('Developers')
-    developerTable
-        .setHeading('', 'Discord', 'Available', 'Goal')  
-
-    // loop through the data and add developer to table
-    for (let i = 0; i < data!.length; i++) {
-        const {discord, available, goal} = data![i];
-        developerTable.addRow(i, discord, available, goal ? goal : "none");
-    }
-
-    // convert table into a codeblock
-    const message = "\n ```" + developerTable.toString() + "```";
-
-    await interaction.reply({
-        content: message,
-        ephemeral: true,
-    });   
+    //Create developer embed + pagination
+    await generateDevelopersPaginator(interaction, data!);
 }

--- a/components/developersPaginator.ts
+++ b/components/developersPaginator.ts
@@ -1,0 +1,171 @@
+import { MessageActionRow, MessageButton, MessageEmbed, MessageSelectMenu } from 'discord.js';
+import { client } from '../index';
+
+export async function generateDevelopersPaginator(interaction: any, developers: any[]) {
+  let page = 0;
+  const PAGE_RECORDS = 25;
+
+  let totalDevelopers = developers!.length;
+  const getCurrentPageDevs = (page: number): any[] => developers!.filter((elem, index, array) => {
+    return index >= page * PAGE_RECORDS && index < page * PAGE_RECORDS + PAGE_RECORDS;
+  })
+
+  //Initializing settings ----- start
+  
+  const developerSelectOptions = _constructDeveloperOptions(getCurrentPageDevs(page))
+  let embed = await _resolveCurrentEmbed(developers!, 0);
+  let maxDeveloperSelections = Math.floor(totalDevelopers / PAGE_RECORDS);
+  if (totalDevelopers % PAGE_RECORDS > 0) maxDeveloperSelections += 1;
+  
+  let menuPlaceholder = (discordTag: string, page: number) => 
+    `Currently viewing ${discordTag} - page ${page + 1} of ${maxDeveloperSelections}`
+
+  let selectMenu = new MessageSelectMenu()
+  .setPlaceholder(menuPlaceholder(developers![0].discord, page))
+  .setOptions(developerSelectOptions)
+  .setCustomId('developer-list')
+  .setMinValues(1)
+  .setMaxValues(1);
+
+  const startButton = new MessageButton()
+  .setLabel('⏪')
+  .setStyle('SECONDARY')
+  .setCustomId('start-button');
+
+  const firstFilterButton = new MessageButton()
+  .setLabel(`-${PAGE_RECORDS}`)
+  .setStyle('PRIMARY')
+  .setCustomId(`filter-${PAGE_RECORDS}`);
+
+  const secondFilterButton = new MessageButton()
+  .setLabel(`+${PAGE_RECORDS}`)
+  .setStyle('PRIMARY')
+  .setCustomId(`filter+${PAGE_RECORDS}`);
+
+  const endButton = new MessageButton()
+  .setLabel('⏩')
+  .setStyle('SECONDARY')
+  .setCustomId('end-button');
+
+  const menuList = [selectMenu];
+  const buttonList = [startButton, firstFilterButton, secondFilterButton, endButton];
+  const firstRow = new MessageActionRow().addComponents(buttonList);
+  let secondRow = new MessageActionRow().addComponents(selectMenu);
+
+  //Initializing settings ----- end
+
+  const curPage = await interaction.reply({
+    content: 'Here are all the developers in my pairing sheet!',
+    embeds: [embed],
+    components: [firstRow, secondRow],
+    fetchReply: true,
+    ephemeral: true
+  });
+
+  const filter = (i: any) => 
+  i.customId === menuList[0].customId ||
+  i.customId === buttonList[0].customId ||
+  i.customId === buttonList[1].customId ||
+  i.customId === buttonList[2].customId ||
+  i.customId === buttonList[3].customId;
+
+  const collector = await curPage.createMessageComponentCollector({
+    filter,
+    time: 60000,
+  })
+
+  //Starts on listening for button component clicks
+  collector.on("collect", async (i: any) => {
+    if (i.isSelectMenu()) {
+      embed = await _resolveCurrentEmbed(
+        getCurrentPageDevs(page), 
+        getCurrentPageDevs(page).findIndex((dev: any) => dev.discord_id === i.values[0])
+        );
+      let selectedDevDiscord = getCurrentPageDevs(page).find(dev => dev.discord_id === i.values[0]).discord;
+      selectMenu.placeholder = menuPlaceholder(selectedDevDiscord, page)
+    }
+
+    if (i.isMessageComponent()){
+      switch (i.customId) {
+        case buttonList[0].customId:
+          page = 0;
+          break; 
+        case buttonList[1].customId:
+          page - 1 < 0 ? 0 : page--;
+          break;
+        case buttonList[2].customId:
+          page + 1 >= maxDeveloperSelections ? maxDeveloperSelections : page++;
+          break;
+        case buttonList[3].customId:
+          page = maxDeveloperSelections - 1;
+          break; 
+        }
+      selectMenu.options = _constructDeveloperOptions(getCurrentPageDevs(page))
+      selectMenu.placeholder = menuPlaceholder(embed.title!.replace("'s profile", ""), page)
+      secondRow.components = [selectMenu];
+    }
+    
+    await i.update({
+      embeds: [embed],
+      components: [firstRow, secondRow],
+    });
+    collector.resetTimer();
+  });
+
+  //Finishes listening and disable buttons
+  collector.on("end", () => {
+    if (!curPage.deleted) {
+      const disabledMenu = new MessageActionRow().addComponents(
+        menuList[0].setDisabled(true),
+      );
+
+      const disabledButtons = new MessageActionRow().addComponents(
+        buttonList[0].setDisabled(true),
+        buttonList[1].setDisabled(true),
+        buttonList[2].setDisabled(true),
+        buttonList[3].setDisabled(true)
+      );
+
+      interaction.editReply({
+        embeds: [embed],
+        components: [disabledMenu, disabledButtons],
+      });
+    }
+  });
+}
+
+//Builds the embed of the current selected developer
+async function _resolveCurrentEmbed(developers: any[], devIndex = 0) {
+  let selectedDeveloper: any = developers!.find((value, index, array) => index === devIndex);
+  let selectedDevId = await client.users.fetch(selectedDeveloper.discord_id);
+  let embed = new MessageEmbed()
+	.setColor('#0099ff')
+	.setTitle(`${selectedDeveloper.discord.charAt(0).toUpperCase() + selectedDeveloper.discord.slice(1)}'s profile`)
+	.setThumbnail(selectedDevId.avatarURL() ?? selectedDevId.defaultAvatarURL)
+	.setDescription(selectedDeveloper.position)
+  .addFields(
+      {name: 'Skills', value: selectedDeveloper.skills}, 
+      {name: 'Desired Skills', value: selectedDeveloper.desired_skills},
+      {name: 'Goal', value: selectedDeveloper.goal ?? "none"},
+      {name: 'Available', value: selectedDeveloper.available ? 'True' : 'False', inline: true},
+      {name: '\u200b', value: '\u200b', inline: true},
+      {name: 'Timezone', value: selectedDeveloper.timezone, inline: true},
+      {name: 'Github', value: `__[github.com/${selectedDeveloper.github}](https://github.com/${selectedDeveloper.github})__`, inline: true},
+      {name: 'Twitter', value: `__[twitter.com/${selectedDeveloper.twitter}](https://twitter.com/${selectedDeveloper.twitter})__`, inline: true},
+  )
+  return embed;   
+}
+
+//Builds the possible options in the dropdown
+function _constructDeveloperOptions(developers: any): any[] {
+  const developerOptions: { label: string; description: string, value: string; }[] = [];
+
+  developers.forEach((dev: { discord: string, discord_id: string, available: boolean, timezone: string }) => {
+      developerOptions.push({
+      label: `#${`${developers.indexOf(dev)}`.padStart(4, '0')}  -  ${dev.discord}`,
+      description: `Available: ${dev.available} - Timezone: ${dev.timezone}`,
+      value: dev.discord_id,
+    });
+  });
+  return developerOptions;
+}


### PR DESCRIPTION
The developers paginator helps better displaying Developers added to the table. 

How does it work?
- Searches all the developers in the Developers table
- Divides the developers by 25 records per page
- Gets the developers needed for the current page and puts them in the discord MessageSelectMenu.options property 
- Embeds as a discord MessageEmbed the currently selected developer on the dropdown menu
- Listens for actions related to dropdown and embeds a new developer when another developer in the dropdown is selected
- Listens for actions related to buttons and changes page when a button is clicked

